### PR TITLE
Untitled

### DIFF
--- a/_build/properties.inc.php
+++ b/_build/properties.inc.php
@@ -202,6 +202,13 @@ $properties = array(
         'value' => '',
     ),
     array(
+        'name' => 'toSeparatePlaceholders',
+        'desc' => 'If set, will assign EACH result to a separate placeholder named by this param suffixed with a sequential number (starting from 0).',
+        'type' => 'textfield',
+        'options' => '',
+        'value' => '',
+    ),
+    array(
         'name' => 'debug',
         'desc' => 'If true, will send the SQL query to the MODx log. Defaults to false.',
         'type' => 'combo-boolean',

--- a/core/components/getresources/snippet.getresources.php
+++ b/core/components/getresources/snippet.getresources.php
@@ -262,6 +262,12 @@ foreach ($collection as $resourceId => $resource) {
 }
 
 /* output */
+$toSeparatePlaceholders = $modx->getOption('toSeparatePlaceholders',$scriptProperties,false);
+if (!empty($toSeparatePlaceholders)) {
+    $modx->setPlaceholders($output,$toSeparatePlaceholders);
+    return '';
+}
+
 $output = implode($outputSeparator, $output);
 $toPlaceholder = $modx->getOption('toPlaceholder',$scriptProperties,false);
 if (!empty($toPlaceholder)) {


### PR DESCRIPTION
This one allows a single getResources call to serve in situations where the results need to be split up in the markup (as opposed to sequential listing).
