### PR TITLE
Sort by resources

### DIFF
--- a/core/components/getresources/snippet.getresources.php
+++ b/core/components/getresources/snippet.getresources.php
@@ -25,6 +25,8 @@
  *
  * parents - Comma-delimited list of ids serving as parents
  *
+ * resources - (Opt) Comma-delimited list of ids for resources, which will be included (positive integer) or excluded (negative integer) from the output collection.  Example: &resources=`1, 2, -3` will include resources of id 1 and 2 and exclude resource of id 3.
+ *
  * depth - (Opt) Integer value indicating depth to search for resources from each parent [default=10]
  *
  * tvFilters - (Opt) Delimited-list of TemplateVar values to filter resources by. Supports two


### PR DESCRIPTION
This addresses issues #13 and #5:
1. Filter out any resources not specified in `resources` parameter. This renders `parents` parameter ineffective, although the children resources still are being fetched.
2. Order resources exactly as they are in `resources` parameter.
3. Added missing description for `resources` parameter.

It's another take on the subject. There were problems with merging the previous one.
