### PR TITLE
Conditional Templates

### DIFF
--- a/core/components/getresources/snippet.getresources.php
+++ b/core/components/getresources/snippet.getresources.php
@@ -536,10 +536,6 @@ foreach ($collection as $resourceId => $resource) {
                     break;
             }
         }
-    	
-    	
-    	
-
     	  if(!empty($tplCon)) {
             $resourceTpl = parseTpl($tplCon, $properties);
         }


### PR DESCRIPTION
Added support for conditional templates. This allows using a different template depending on a field or TV of the resource being displayed.

New parameters:

$tplCondition - the name of the field or TV (including TV prefix) on which the template depends

$tplOperator - optional comparison operator - defaults to equals - supports all operators used by the If snippet (uses the same code)

$conditionalTpls - JSON array of values for comparison to $tplCondition and corresponding chunk names to use as a template if the comparison succeeds
