### PR TITLE
Added placeholder variables to snippet

### DIFF
--- a/core/components/getresources/snippet.getresources.php
+++ b/core/components/getresources/snippet.getresources.php
@@ -432,6 +432,9 @@ foreach ($collection as $resourceId => $resource) {
             'idx' => $idx
             ,'first' => $first
             ,'last' => $last
+            , '_first' => ($idx == $first)
+            , '_last' => ($idx == $last)
+            , '_alt' => $odd
         )
         ,$includeContent ? $resource->toArray() : $resource->get($fields)
         ,$tvs


### PR DESCRIPTION
There is already the possibility to select the template for the first, last,... items, but if you just want to set some CSS class on a container it is quite complex to create chunks.

This idea was inspired by the getImageList-Snippet from MIGX, you can see the usage of these placeholders here:
http://rtfm.modx.com/display/ADDON/MIGX.Frontend-Usage#MIGX.Frontend-Usage-tplplaceholders

According to the getImageList-Snippet I now added the same placeholders for the getResource-Snippet:
- _first: true if item is the first item in list
- _last: true if item is the last item in list
- _alt: true every second row
