### PR TITLE
Output resource.properties as JSON (not Array)

### DIFF
--- a/core/components/getresources/snippet.getresources.php
+++ b/core/components/getresources/snippet.getresources.php
@@ -457,6 +457,7 @@ foreach ($collection as $resourceId => $resource) {
         ,$includeContent ? $resource->toArray() : $resource->get($fields)
         ,$tvs
     );
+    $properties['properties'] = $modx->toJSON($properties['properties']);
     $resourceTpl = '';
     if ($idx == $first && !empty($tplFirst)) {
         $resourceTpl = parseTpl($tplFirst, $properties);


### PR DESCRIPTION
Set modResource.properties as JSON, because modChunk seem disregard an Array.
