### PR TITLE
Fix bug when filter operation (==,<=> or other) contains in field value.

### DIFF
--- a/_build/build.transport.php
+++ b/_build/build.transport.php
@@ -31,8 +31,8 @@ $modx->setLogTarget(XPDO_CLI_MODE ? 'ECHO' : 'HTML');
 
 /* set package info */
 define('PKG_NAME','getresources');
-define('PKG_VERSION','1.6.0');
-define('PKG_RELEASE','pl');
+define('PKG_VERSION','1.6.1');
+define('PKG_RELEASE','a1');
 
 /* load builder */
 $modx->loadClass('transport.modPackageBuilder','',false, true);

--- a/core/components/getresources/snippet.getresources.php
+++ b/core/components/getresources/snippet.getresources.php
@@ -260,7 +260,13 @@ if (!empty($tvFilters)) {
             $tvValueField = 'tvr.value';
             $tvDefaultField = 'tv.default_text';
             $f = explode($operator, $filter);
-            if (count($f) == 2) {
+            if (count($f) >= 2) {
+                //Fix values with $operator in field value
+                if(count($f)>2) {
+                    $k=array_shift($f);
+                    $b=join($operator,$f);
+                    $f=array($k,$b);
+                }
                 $tvName = $modx->quote($f[0]);
                 if (is_numeric($f[1]) && !in_array($sqlOperator, array('LIKE', 'NOT LIKE'))) {
                     $tvValue = $f[1];


### PR DESCRIPTION
Patch fixing when in filter value contains special symbols used as filter operator.

Signed-off-by: Egor Bolgov egor.b@fabricasaitov.ru
