### PR TITLE
#43 Allow 0 based idx

### DIFF
--- a/core/components/getresources/snippet.getresources.php
+++ b/core/components/getresources/snippet.getresources.php
@@ -417,7 +417,7 @@ if (!empty($debug)) {
 }
 $collection = $modx->getCollection('modResource', $criteria, $dbCacheFlag);
 
-$idx = !empty($idx) && $idx !== '0' ? (integer) $idx : 1;
+$idx = !empty($idx) || $idx === '0' ? (integer) $idx : 1;
 $first = empty($first) && $first !== '0' ? 1 : (integer) $first;
 $last = empty($last) ? (count($collection) + $idx - 1) : (integer) $last;
 


### PR DESCRIPTION
Lets '0' pass the ternary allowing a value of 0 to be passed to idx.
