### PR TITLE
Sort output order of resource IDs like input order AKA keep the sequence alive

### DIFF
--- a/core/components/getresources/snippet.getresources.php
+++ b/core/components/getresources/snippet.getresources.php
@@ -414,6 +414,9 @@ if (!empty($sortby)) {
     }
     if (is_array($sorts)) {
         while (list($sort, $dir) = each($sorts)) {
+            if ($sort == 'resources' && !empty($resources)) {
+                $sort = 'FIELD(modResource.id, ' . implode($resources,',') . ')';            
+            }
             if ($sortbyEscaped) $sort = $modx->escape($sort);
             if (!empty($sortbyAlias)) $sort = $modx->escape($sortbyAlias) . ".{$sort}";
             $criteria->sortby($sort, $dir);


### PR DESCRIPTION
Now you can use:
```[[!getResources? &resources=`4,3,2,5` &sortby=`resources` &tpl=`tpl.item`]]```
OR
```[[!getResources? &resources=`4,3,2,5` &sortby=`{"resources":"DESC"}` &tpl=`tpl.item`]]```
MODX CCC w/ @pepimpepa