### PR TITLE
Make output order of resources like input order

### DIFF
--- a/core/components/getresources/snippet.getresources.php
+++ b/core/components/getresources/snippet.getresources.php
@@ -410,6 +410,10 @@ if (!empty($sortby)) {
     if (strpos($sortby, '{') === 0) {
         $sorts = $modx->fromJSON($sortby);
     } else {
+        if (strtolower($sortby) == "resources") {
+            $resources__csv = implode(',',$resources);
+            $sortby= "FIELD(modResource.id,{$resources__csv})";
+        }
         $sorts = array($sortby => $sortdir);
     }
     if (is_array($sorts)) {


### PR DESCRIPTION
To preserve the CSV order of `&resources` one has to manually insert `&sortby='FIELD(modResource.id,[[+myResources]])'`. This is a possible way how do do it but I thought it would be nicer if we had the `sortby` token "resources" which ads this behavior automatically.

I hope you like my little addition and will merge it. Or just feel free to modify it.

cheers
Oliver