### PR TITLE
A short placeholder for properties

### DIFF
--- a/core/components/getresources/snippet.getresources.php
+++ b/core/components/getresources/snippet.getresources.php
@@ -471,6 +471,7 @@ foreach ($collection as $resourceId => $resource) {
             ,'first' => $first
             ,'last' => $last
             ,'odd' => $odd
+            ,'prop' => $resource->get('properties')
         )
         ,$includeContent ? $resource->toArray() : $resource->get($fields)
         ,$tvs


### PR DESCRIPTION
It would be nice to add a short name for "properties", for a more convenient use.

I want to do this so that you can enter not only:
```
[[+properties.tvc.tv1]]
```

but a shorter version:
```
[[+prop.tvc.tv1]]
```